### PR TITLE
Fix/page to delete does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Directory error
 
 ## [1.0.0] - 2020-08-04
 ### Added

--- a/node/errors/responseError.ts
+++ b/node/errors/responseError.ts
@@ -1,0 +1,5 @@
+export async function returnResponseError(message: string, code: string, ctx: Context, next: () => Promise<any>){
+  ctx.status = 404
+  ctx.body = `{"message": "${message}", "code": "${code}"}`
+  await next()
+}

--- a/node/middlewares/checkPublishedApp.ts
+++ b/node/middlewares/checkPublishedApp.ts
@@ -1,12 +1,7 @@
 import { parseAppId } from '@vtex/api'
 import { json } from 'co-body'
 import { InstallResponse } from '../clients/billing'
-
-async function didNotFindAppResponse(message: string, code: string, ctx: Context, next: () => Promise<any>){
-  ctx.status = 404
-  ctx.body = `{"message": "${message}", "code": "${code}"}`
-  await next()
-}
+import { returnResponseError } from '../errors/responseError'
 
 export async function checkPublishedApp(
   ctx: Context,
@@ -23,7 +18,7 @@ export async function checkPublishedApp(
     await ctx.clients.registry.getAppManifest(name, version)
   } catch(err) {
     logger.warn(`Could not find ${name}`)
-    await didNotFindAppResponse('Error in build - could not find app', 'BUILD_FAILED', ctx, next)
+    await returnResponseError('Error in build - could not find app', 'BUILD_FAILED', ctx, next)
     return
   }
 
@@ -32,7 +27,7 @@ export async function checkPublishedApp(
     installResponse = await ctx.clients.billings.installApp(appID, true, false)
   } catch(err) {
     logger.warn(`Could not install ${name}`)
-    await didNotFindAppResponse(JSON.stringify(installResponse), 'INSTALLATION_ERROR', ctx, next)
+    await returnResponseError(JSON.stringify(installResponse), 'INSTALLATION_ERROR', ctx, next)
     return
   }
 

--- a/node/middlewares/unpublishPage.ts
+++ b/node/middlewares/unpublishPage.ts
@@ -5,6 +5,7 @@ import { parseAppId } from '@vtex/api'
 import { ensureDir } from 'fs-extra'
 import { extractFilesAndRemovePage, getFilesForBuilderHub } from '../util/appFiles'
 import { bumpPatchVersion } from '../util/versionControl'
+import { returnResponseError } from '../errors/responseError'
 
 const jsonResponse = (newAppID: string) => `{"buildId": "${newAppID}"}`
 
@@ -45,7 +46,13 @@ export async function unpublishPage(
     false
   )
   const sourceCodePath = `${filePath}/src`
-  const appFiles = await extractFilesAndRemovePage(pageToDelete, sourceCodePath, sourceCodePath, version)
+
+  let appFiles
+  try {
+    appFiles = await extractFilesAndRemovePage(pageToDelete, sourceCodePath, sourceCodePath, version)
+  } catch(err){
+    return returnResponseError('Could not find page to delete', 'PAGE_NOT_FOUND', ctx, next)
+  }
 
   const files = getFilesForBuilderHub(appFiles)
 


### PR DESCRIPTION
When deleting a page that is not in the previous store-builder app, the service will now return an error instead of breaking