### PR TITLE
File names are now the meta.page of the CMS input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fix
+- File names are now the meta.page
 
 ## [1.0.4] - 2020-08-07
 ### Fix

--- a/node/util/appFiles.ts
+++ b/node/util/appFiles.ts
@@ -15,7 +15,7 @@ export interface AppFiles {
 export async function createNewAppFiles(uploadFile: UploadFile, version: string, account: string){
   const pageFile: File = {
     content: uploadFile.file,
-    path: `store/blocks/${uploadFile.title}.json`,
+    path: `store/blocks/${uploadFile.page}.json`,
   }
   const manifest = await makeDefaultManifest(
     STORE_STATE,
@@ -90,7 +90,7 @@ async function extractFiles(path: string, mainPath: string){
 function updateAppFiles(appFiles: AppFiles, uploadFile: UploadFile, version: string){
   let foundFile = false
   appFiles.files.forEach(file => {
-    if(file.path.includes(`${uploadFile.title}.json`)) {
+    if(file.path.includes(`${uploadFile.page}.json`)) {
       file.content = uploadFile.file
       foundFile = true
     }
@@ -108,7 +108,7 @@ function updateAppFiles(appFiles: AppFiles, uploadFile: UploadFile, version: str
 function addPage(appFiles: AppFiles, uploadFile: UploadFile){
   const newPageFile: File = {
     content: uploadFile.file,
-    path: `store/blocks/${uploadFile.title}.json`,
+    path: `store/blocks/${uploadFile.page}.json`,
   }
   appFiles.files.push(newPageFile)
   appFiles.routes = addRoute(appFiles.routes, uploadFile.page, uploadFile.slug)


### PR DESCRIPTION
The meta.page input from the CMS is unique for each page, so it is better to use that as the file name instead of the title of the page.