### PR TITLE
Increase and sync timeouts from service and clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fix
+- Increases timeout on client and services
 
 ## [1.2.0] - 2020-08-26
 

--- a/node/index.ts
+++ b/node/index.ts
@@ -16,7 +16,7 @@ import { methodNotAllowed } from './middlewares/methodNotAllowed'
 import { publishStoreFromPage } from './middlewares/publishStoreFromPage'
 import { unpublishPage } from './middlewares/unpublishPage'
 
-const TIMEOUT_MS = 8000
+const TIMEOUT_MS = 10000
 
 // Create a LRU memory cache for the Status client.
 // The @vtex/api HttpClient respects Cache-Control headers and uses the provided cache.

--- a/node/middlewares/checkPublishedApp.ts
+++ b/node/middlewares/checkPublishedApp.ts
@@ -17,7 +17,7 @@ export async function checkPublishedApp(
   try {
     await ctx.clients.registry.getAppManifest(name, version)
   } catch (err) {
-    logger.warn(`Could not find ${name}`)
+    logger.error(`Could not find ${name} - ${err}`)
     await returnResponseError({
       message: 'Error in build - could not find app',
       code: 'BUILD_FAILED',
@@ -33,7 +33,7 @@ export async function checkPublishedApp(
   try {
     installResponse = await ctx.clients.billings.installApp(appID, true, false)
   } catch (err) {
-    logger.warn(`Could not install ${name}`)
+    logger.error(`Could not install ${name} - ${err}`)
     await returnResponseError({
       message: JSON.stringify(installResponse),
       code: 'INSTALLATION_ERROR',

--- a/node/service.json
+++ b/node/service.json
@@ -1,7 +1,7 @@
 {
   "memory": 256,
   "ttl": 10,
-  "timeout": 2,
+  "timeout": 10,
   "minReplicas": 2,
   "maxReplicas": 4,
   "routes": {


### PR DESCRIPTION
This PR increases timeouts to be sync with clients, I think 10 it's a good value but we can discuss this and go back to 8 if you have any problems with other services.