### PR TITLE
Add retry option for check manifest for app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Retry option to check installed app
 
 ## [1.2.1] - 2020-09-01
 ### Fix

--- a/node/middlewares/checkPublishedApp.ts
+++ b/node/middlewares/checkPublishedApp.ts
@@ -1,8 +1,42 @@
-import { parseAppId } from '@vtex/api'
+import { parseAppId, Registry } from '@vtex/api'
 import { json } from 'co-body'
 
 import { InstallResponse } from '../clients/billing'
 import { returnResponseError } from '../errors/responseError'
+
+const MAX_RETRIES = 5
+const RETRY_TIMEOUT_MS = 1000
+
+const delay = (time: number) => {
+  return new Promise(resolve => setTimeout(resolve, time))
+}
+
+interface RetryCheckApp {
+  registry: Registry
+  name: string
+  version: string
+  retryCount?: number
+}
+
+const retryCheckApp = async ({
+  registry,
+  name,
+  version,
+  retryCount = 0,
+}: RetryCheckApp): Promise<any> => {
+  if (retryCount++ >= MAX_RETRIES) {
+    throw new Error('Max retries exceeded')
+  }
+
+  try {
+    await registry.getAppManifest(name, version)
+  } catch (err) {
+    console.info('Retrying', retryCount)
+    await delay(RETRY_TIMEOUT_MS)
+
+    return retryCheckApp({ registry, name, version, retryCount })
+  }
+}
 
 export async function checkPublishedApp(
   ctx: Context,
@@ -15,11 +49,11 @@ export async function checkPublishedApp(
   const { name, version } = parseAppId(appID)
 
   try {
-    await ctx.clients.registry.getAppManifest(name, version)
+    await retryCheckApp({ registry: ctx.clients.registry, name, version })
   } catch (err) {
     logger.error(`Could not find ${name} - ${err}`)
     await returnResponseError({
-      message: 'Error in build - could not find app',
+      message: `Error in build - could not find app ${name}:${version}`,
       code: 'BUILD_FAILED',
       ctx,
       next,


### PR DESCRIPTION
Retry 5 times before return an error for App not installed, it is necessary when the App was just pushed and is not ready yet.

![image](https://user-images.githubusercontent.com/342161/92133067-556dc000-edde-11ea-95d2-6ce3080b195d.png)
