### PR TITLE
Fix/Extra-pages-appearing

### DIFF
--- a/node/middlewares/listFiles.ts
+++ b/node/middlewares/listFiles.ts
@@ -1,5 +1,5 @@
 import { parseAppId } from '@vtex/api'
-import { ensureDir } from 'fs-extra'
+import { emptyDir } from 'fs-extra'
 import streamToPromise from 'stream-to-promise'
 
 import { STORE_STATE } from '../util/constants'
@@ -36,7 +36,7 @@ export async function listFiles(ctx: Context, next: () => Promise<any>) {
 
   const filePath = 'appFilesFromRegistry'
 
-  await ensureDir(filePath)
+  await emptyDir(filePath)
   const oldVersion = parseAppId(appID).version
   const stream = await ctx.clients.registry.unpackAppBundle(
     appName,

--- a/node/middlewares/publishStoreFromPage.ts
+++ b/node/middlewares/publishStoreFromPage.ts
@@ -2,7 +2,7 @@ import { createHash } from 'crypto'
 
 import { parseAppId } from '@vtex/api'
 import { json } from 'co-body'
-import { ensureDir } from 'fs-extra'
+import { emptyDir } from 'fs-extra'
 import streamToPromise from 'stream-to-promise'
 
 import { returnResponseError } from '../errors/responseError'
@@ -99,7 +99,7 @@ export async function publishStoreFromPage(
   } else {
     const filePath = 'appFilesFromRegistry'
 
-    await ensureDir(filePath)
+    await emptyDir(filePath)
     const oldVersion = parseAppId(appID).version
     const stream = await ctx.clients.registry.unpackAppBundle(
       appName,

--- a/node/util/extractFiles.ts
+++ b/node/util/extractFiles.ts
@@ -1,5 +1,5 @@
 import { File } from '@vtex/api/lib/clients/infra/Registry'
-import { ensureDir, pathExists, remove, writeJSON } from 'fs-extra'
+import { pathExists, remove, writeJSON, emptyDir } from 'fs-extra'
 
 export async function createBaseFolderWithStore(
   path: string,
@@ -8,7 +8,7 @@ export async function createBaseFolderWithStore(
 ) {
   const newPath = createBaseFolder(path, account, workspace)
 
-  await ensureDir(`${newPath}/store`)
+  await emptyDir(`${newPath}/store`)
 
   return newPath
 }
@@ -24,7 +24,7 @@ export async function createBaseFolder(
 
   const newPath = `${path}/${account}/${workspace}`
 
-  await ensureDir(newPath)
+  await emptyDir(newPath)
 
   return newPath
 }
@@ -63,7 +63,7 @@ export async function extractFiles(body: any, path: string, mainPath: string) {
 async function makeFolder(path: string, name: string) {
   const newPath = `${path}/${name}`
 
-  await ensureDir(newPath)
+  await emptyDir(newPath)
 
   return newPath
 }


### PR DESCRIPTION
Since the API uses the local machine to save some files, it is necessary to make sure that these folders are empty before using them, making sure that there is no interference from previous store-state versions.